### PR TITLE
Specify a return type for `ApiVideoMediaRecorder.stop`

### DIFF
--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,4 +1,4 @@
-import { ProgressiveUploaderOptionsWithUploadToken, ProgressiveUploaderOptionsWithAccessToken } from "@api.video/video-uploader";
+import { ProgressiveUploaderOptionsWithUploadToken, ProgressiveUploaderOptionsWithAccessToken, VideoUploadResponse } from "@api.video/video-uploader";
 export interface Options {
     title?: string;
 }
@@ -11,7 +11,7 @@ export declare class ApiVideoMediaRecorder {
     start(options?: {
         timeslice?: number;
     }): void;
-    stop(): Promise<unknown>;
+    stop(): Promise<VideoUploadResponse>;
     pause(): void;
     private getSupportedMimeTypes;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@api.video/video-uploader": "^1.0.2",
+        "@api.video/video-uploader": "^1.0.4",
         "core-js": "^3.8.3"
       },
       "devDependencies": {
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@api.video/video-uploader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@api.video/video-uploader/-/video-uploader-1.0.2.tgz",
-      "integrity": "sha512-RwTd+NbiT/WnZAaKrEAeRdTecYxZRPZmLnCilH9WS5U9HwEhKUHCjKMlLKheQRkmYuIwu5hlO+d0t5ppCdZqmg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@api.video/video-uploader/-/video-uploader-1.0.4.tgz",
+      "integrity": "sha512-1z3eJXOmUInZWDMiH9lbXDCcP/YWI1zQ+RDm2xeaGPEgTTEkAPBd4zGuSIaMF7gyW1cAmfmveQ8WBxQNl+c7lA==",
       "dependencies": {
         "core-js": "^3.8.3"
       }
@@ -3438,9 +3438,9 @@
   },
   "dependencies": {
     "@api.video/video-uploader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@api.video/video-uploader/-/video-uploader-1.0.2.tgz",
-      "integrity": "sha512-RwTd+NbiT/WnZAaKrEAeRdTecYxZRPZmLnCilH9WS5U9HwEhKUHCjKMlLKheQRkmYuIwu5hlO+d0t5ppCdZqmg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@api.video/video-uploader/-/video-uploader-1.0.4.tgz",
+      "integrity": "sha512-1z3eJXOmUInZWDMiH9lbXDCcP/YWI1zQ+RDm2xeaGPEgTTEkAPBd4zGuSIaMF7gyW1cAmfmveQ8WBxQNl+c7lA==",
       "requires": {
         "core-js": "^3.8.3"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@api.video/video-uploader": "^1.0.2",
+    "@api.video/video-uploader": "^1.0.4",
     "core-js": "^3.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ProgressiveUploader, ProgressiveUploaderOptionsWithUploadToken, ProgressiveUploaderOptionsWithAccessToken } from "@api.video/video-uploader";
+import { ProgressiveUploader, ProgressiveUploaderOptionsWithUploadToken, ProgressiveUploaderOptionsWithAccessToken, VideoUploadResponse } from "@api.video/video-uploader";
 
 export interface Options {
     title?: string;
@@ -7,7 +7,7 @@ export interface Options {
 export class ApiVideoMediaRecorder {
     private mediaRecorder: MediaRecorder;
     private streamUpload: ProgressiveUploader;
-    private onVideoAvailable?: (video: any) => void;
+    private onVideoAvailable?: (video: VideoUploadResponse) => void;
 
     constructor(mediaStream: MediaStream, options: ProgressiveUploaderOptionsWithUploadToken | ProgressiveUploaderOptionsWithAccessToken) {
         const supportedTypes = this.getSupportedMimeTypes();
@@ -40,7 +40,7 @@ export class ApiVideoMediaRecorder {
         this.mediaRecorder.start(options?.timeslice || 5000);
     }
 
-    public stop() {
+    public stop(): Promise<VideoUploadResponse> {
         this.mediaRecorder.stop();
         return new Promise((resolve, reject) => {
             this.onVideoAvailable = (v) => resolve(v)


### PR DESCRIPTION
This is the follow-up from https://github.com/apivideo/api.video-typescript-uploader/pull/14 to actually set the return type of `ApiVideoMediaRecorder.stop`.

I've opened it as a draft, it would need to be updated once the linked PR is merged/released (assuming the change is accepted!).

---

- 38f13ff **Specify a return type for `ApiVideoMediaRecorder.stop`**

  This makes it easier to work with the returned value from TypeScript.
